### PR TITLE
Fix for build issues caused by beta Analyzers

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -23,7 +23,7 @@ env:
   CHOCO_PACKAGE_REPO_FOLDER: 'chocolatey-packages'
   CHOCO_SRC_DIR: 'choco-src'
   CODE_COVERAGE_THRESHOLD: 0
-  DOTNET_VERSION: '3.1.200'
+  DOTNET_VERSION: '5.0.x'
   OUTPUT_DIR: 'dist'    
   NUGET_SOURCE_NAME: 'AzureIntegrationMigration'  
   PUBLISHED_PROJECT_FILE: 'src/Microsoft.AzureIntegrationMigration.Tool/Microsoft.AzureIntegrationMigration.Tool.csproj'

--- a/Microsoft.AzureIntegrationMigration.Tool.sln
+++ b/Microsoft.AzureIntegrationMigration.Tool.sln
@@ -13,17 +13,17 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		version-suffix.txt = version-suffix.txt
 	EndProjectSection
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.AzureIntegrationMigration.Tool.Mocks.Discover", "tests\Microsoft.AzureIntegrationMigration.Tool.Mocks.Discover\Microsoft.AzureIntegrationMigration.Tool.Mocks.Discover.csproj", "{0387E190-29AE-41AC-948E-147F7E062210}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.AzureIntegrationMigration.Tool.Mocks.Discover", "tests\Microsoft.AzureIntegrationMigration.Tool.Mocks.Discover\Microsoft.AzureIntegrationMigration.Tool.Mocks.Discover.csproj", "{0387E190-29AE-41AC-948E-147F7E062210}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.AzureIntegrationMigration.Tool.Mocks.Parse", "tests\Microsoft.AzureIntegrationMigration.Tool.Mocks.Parse\Microsoft.AzureIntegrationMigration.Tool.Mocks.Parse.csproj", "{35FFB01D-4FCA-48AB-991D-1D5227785ED9}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.AzureIntegrationMigration.Tool.Mocks.Parse", "tests\Microsoft.AzureIntegrationMigration.Tool.Mocks.Parse\Microsoft.AzureIntegrationMigration.Tool.Mocks.Parse.csproj", "{35FFB01D-4FCA-48AB-991D-1D5227785ED9}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.AzureIntegrationMigration.Tool.Mocks.Analyze", "tests\Microsoft.AzureIntegrationMigration.Tool.Mocks.Analyze\Microsoft.AzureIntegrationMigration.Tool.Mocks.Analyze.csproj", "{D7B86F1D-D830-4615-A402-DDFD2C394D4A}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.AzureIntegrationMigration.Tool.Mocks.Analyze", "tests\Microsoft.AzureIntegrationMigration.Tool.Mocks.Analyze\Microsoft.AzureIntegrationMigration.Tool.Mocks.Analyze.csproj", "{D7B86F1D-D830-4615-A402-DDFD2C394D4A}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.AzureIntegrationMigration.Tool.Mocks.Report", "tests\Microsoft.AzureIntegrationMigration.Tool.Mocks.Report\Microsoft.AzureIntegrationMigration.Tool.Mocks.Report.csproj", "{C98CA170-AFDB-41ED-8D33-1853A66D88F3}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.AzureIntegrationMigration.Tool.Mocks.Report", "tests\Microsoft.AzureIntegrationMigration.Tool.Mocks.Report\Microsoft.AzureIntegrationMigration.Tool.Mocks.Report.csproj", "{C98CA170-AFDB-41ED-8D33-1853A66D88F3}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.AzureIntegrationMigration.Tool.Mocks.Convert", "tests\Microsoft.AzureIntegrationMigration.Tool.Mocks.Convert\Microsoft.AzureIntegrationMigration.Tool.Mocks.Convert.csproj", "{4EE37E8A-7A9C-4125-8121-8E0EB7DC752A}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.AzureIntegrationMigration.Tool.Mocks.Convert", "tests\Microsoft.AzureIntegrationMigration.Tool.Mocks.Convert\Microsoft.AzureIntegrationMigration.Tool.Mocks.Convert.csproj", "{4EE37E8A-7A9C-4125-8121-8E0EB7DC752A}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.AzureIntegrationMigration.Tool.Mocks.Verify", "tests\Microsoft.AzureIntegrationMigration.Tool.Mocks.Verify\Microsoft.AzureIntegrationMigration.Tool.Mocks.Verify.csproj", "{EB4B955D-E061-4801-B9D3-859EE7418416}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.AzureIntegrationMigration.Tool.Mocks.Verify", "tests\Microsoft.AzureIntegrationMigration.Tool.Mocks.Verify\Microsoft.AzureIntegrationMigration.Tool.Mocks.Verify.csproj", "{EB4B955D-E061-4801-B9D3-859EE7418416}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/nuget.config
+++ b/nuget.config
@@ -4,6 +4,6 @@
     <!--To inherit the global NuGet package sources remove the <clear/> line below -->
     <clear />
 	  <add key="AzureIntegrationMigration" value="https://nuget.pkg.github.com/azure/index.json" />
-    <add key="nuget" value="https://api.nuget.org/v3/index.json" />    
+      <add key="nuget" value="https://api.nuget.org/v3/index.json" />    
   </packageSources>
 </configuration>

--- a/nuget.config
+++ b/nuget.config
@@ -4,6 +4,6 @@
     <!--To inherit the global NuGet package sources remove the <clear/> line below -->
     <clear />
 	  <add key="AzureIntegrationMigration" value="https://nuget.pkg.github.com/azure/index.json" />
-      <add key="nuget" value="https://api.nuget.org/v3/index.json" />    
+    <add key="nuget" value="https://api.nuget.org/v3/index.json" />    
   </packageSources>
 </configuration>

--- a/nuget.config
+++ b/nuget.config
@@ -4,7 +4,6 @@
     <!--To inherit the global NuGet package sources remove the <clear/> line below -->
     <clear />
 	  <add key="AzureIntegrationMigration" value="https://nuget.pkg.github.com/azure/index.json" />
-    <add key="nuget" value="https://api.nuget.org/v3/index.json" />
-    <add key="roslyn" value="https://dotnet.myget.org/F/roslyn/api/v3/index.json" />
+    <add key="nuget" value="https://api.nuget.org/v3/index.json" />    
   </packageSources>
 </configuration>

--- a/src/Microsoft.AzureIntegrationMigration.Tool/Microsoft.AzureIntegrationMigration.Tool.csproj
+++ b/src/Microsoft.AzureIntegrationMigration.Tool/Microsoft.AzureIntegrationMigration.Tool.csproj
@@ -25,7 +25,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AzureIntegrationMigration.Runner" Version="0.5.1" />
+    <PackageReference Include="Microsoft.AzureIntegrationMigration.Runner" Version="0.5.2-beta.2021042827726" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.8" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.8" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="3.1.8" />

--- a/src/Microsoft.AzureIntegrationMigration.Tool/Microsoft.AzureIntegrationMigration.Tool.csproj
+++ b/src/Microsoft.AzureIntegrationMigration.Tool/Microsoft.AzureIntegrationMigration.Tool.csproj
@@ -10,7 +10,9 @@
     <Copyright>Copyright © Microsoft Corporation 2020</Copyright>
     <AssemblyName>aim</AssemblyName>
     <AssemblyTitle>Microsoft Azure Integration Migration Tool</AssemblyTitle>
-    <ApplicationIcon>azure.ico</ApplicationIcon>    
+    <ApplicationIcon>azure.ico</ApplicationIcon>
+    <CodeAnalysisTreatWarningsAsErrors>true</CodeAnalysisTreatWarningsAsErrors>
+    <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
@@ -24,14 +26,6 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AzureIntegrationMigration.Runner" Version="0.5.1" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeStyle" Version="3.8.0">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="5.0.3">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.8" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.8" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="3.1.8" />

--- a/src/Microsoft.AzureIntegrationMigration.Tool/Microsoft.AzureIntegrationMigration.Tool.csproj
+++ b/src/Microsoft.AzureIntegrationMigration.Tool/Microsoft.AzureIntegrationMigration.Tool.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <NeutralLanguage>en</NeutralLanguage>
     <Authors>Microsoft Corporation</Authors>
     <Product>Microsoft Azure Integration Migration Tool</Product>

--- a/tests/Microsoft.AzureIntegrationMigration.Tool.Mocks.Analyze/Microsoft.AzureIntegrationMigration.Tool.Mocks.Analyze.csproj
+++ b/tests/Microsoft.AzureIntegrationMigration.Tool.Mocks.Analyze/Microsoft.AzureIntegrationMigration.Tool.Mocks.Analyze.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <CodeAnalysisTreatWarningsAsErrors>true</CodeAnalysisTreatWarningsAsErrors>
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>

--- a/tests/Microsoft.AzureIntegrationMigration.Tool.Mocks.Analyze/Microsoft.AzureIntegrationMigration.Tool.Mocks.Analyze.csproj
+++ b/tests/Microsoft.AzureIntegrationMigration.Tool.Mocks.Analyze/Microsoft.AzureIntegrationMigration.Tool.Mocks.Analyze.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AzureIntegrationMigration.Runner" Version="0.5.1" />
+    <PackageReference Include="Microsoft.AzureIntegrationMigration.Runner" Version="0.5.2-beta.2021042827726" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="3.1.8" />
     <PackageReference Include="System.Text.Json" Version="4.7.2" />
   </ItemGroup>

--- a/tests/Microsoft.AzureIntegrationMigration.Tool.Mocks.Analyze/Microsoft.AzureIntegrationMigration.Tool.Mocks.Analyze.csproj
+++ b/tests/Microsoft.AzureIntegrationMigration.Tool.Mocks.Analyze/Microsoft.AzureIntegrationMigration.Tool.Mocks.Analyze.csproj
@@ -2,6 +2,8 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
+    <CodeAnalysisTreatWarningsAsErrors>true</CodeAnalysisTreatWarningsAsErrors>
+    <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
 

--- a/tests/Microsoft.AzureIntegrationMigration.Tool.Mocks.Convert/Microsoft.AzureIntegrationMigration.Tool.Mocks.Convert.csproj
+++ b/tests/Microsoft.AzureIntegrationMigration.Tool.Mocks.Convert/Microsoft.AzureIntegrationMigration.Tool.Mocks.Convert.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <CodeAnalysisTreatWarningsAsErrors>true</CodeAnalysisTreatWarningsAsErrors>
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>

--- a/tests/Microsoft.AzureIntegrationMigration.Tool.Mocks.Convert/Microsoft.AzureIntegrationMigration.Tool.Mocks.Convert.csproj
+++ b/tests/Microsoft.AzureIntegrationMigration.Tool.Mocks.Convert/Microsoft.AzureIntegrationMigration.Tool.Mocks.Convert.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AzureIntegrationMigration.Runner" Version="0.5.1" />
+    <PackageReference Include="Microsoft.AzureIntegrationMigration.Runner" Version="0.5.2-beta.2021042827726" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="3.1.8" />
   </ItemGroup>
 

--- a/tests/Microsoft.AzureIntegrationMigration.Tool.Mocks.Convert/Microsoft.AzureIntegrationMigration.Tool.Mocks.Convert.csproj
+++ b/tests/Microsoft.AzureIntegrationMigration.Tool.Mocks.Convert/Microsoft.AzureIntegrationMigration.Tool.Mocks.Convert.csproj
@@ -2,6 +2,8 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
+    <CodeAnalysisTreatWarningsAsErrors>true</CodeAnalysisTreatWarningsAsErrors>
+    <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
 

--- a/tests/Microsoft.AzureIntegrationMigration.Tool.Mocks.Discover/Microsoft.AzureIntegrationMigration.Tool.Mocks.Discover.csproj
+++ b/tests/Microsoft.AzureIntegrationMigration.Tool.Mocks.Discover/Microsoft.AzureIntegrationMigration.Tool.Mocks.Discover.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <CodeAnalysisTreatWarningsAsErrors>true</CodeAnalysisTreatWarningsAsErrors>
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>

--- a/tests/Microsoft.AzureIntegrationMigration.Tool.Mocks.Discover/Microsoft.AzureIntegrationMigration.Tool.Mocks.Discover.csproj
+++ b/tests/Microsoft.AzureIntegrationMigration.Tool.Mocks.Discover/Microsoft.AzureIntegrationMigration.Tool.Mocks.Discover.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AzureIntegrationMigration.Runner" Version="0.5.1" />
+    <PackageReference Include="Microsoft.AzureIntegrationMigration.Runner" Version="0.5.2-beta.2021042827726" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="3.1.8" />
   </ItemGroup>
 

--- a/tests/Microsoft.AzureIntegrationMigration.Tool.Mocks.Discover/Microsoft.AzureIntegrationMigration.Tool.Mocks.Discover.csproj
+++ b/tests/Microsoft.AzureIntegrationMigration.Tool.Mocks.Discover/Microsoft.AzureIntegrationMigration.Tool.Mocks.Discover.csproj
@@ -2,6 +2,8 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
+    <CodeAnalysisTreatWarningsAsErrors>true</CodeAnalysisTreatWarningsAsErrors>
+    <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
 

--- a/tests/Microsoft.AzureIntegrationMigration.Tool.Mocks.Parse/Microsoft.AzureIntegrationMigration.Tool.Mocks.Parse.csproj
+++ b/tests/Microsoft.AzureIntegrationMigration.Tool.Mocks.Parse/Microsoft.AzureIntegrationMigration.Tool.Mocks.Parse.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <CodeAnalysisTreatWarningsAsErrors>true</CodeAnalysisTreatWarningsAsErrors>
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>

--- a/tests/Microsoft.AzureIntegrationMigration.Tool.Mocks.Parse/Microsoft.AzureIntegrationMigration.Tool.Mocks.Parse.csproj
+++ b/tests/Microsoft.AzureIntegrationMigration.Tool.Mocks.Parse/Microsoft.AzureIntegrationMigration.Tool.Mocks.Parse.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AzureIntegrationMigration.Runner" Version="0.5.1" />
+    <PackageReference Include="Microsoft.AzureIntegrationMigration.Runner" Version="0.5.2-beta.2021042827726" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="3.1.8" />
   </ItemGroup>
 

--- a/tests/Microsoft.AzureIntegrationMigration.Tool.Mocks.Parse/Microsoft.AzureIntegrationMigration.Tool.Mocks.Parse.csproj
+++ b/tests/Microsoft.AzureIntegrationMigration.Tool.Mocks.Parse/Microsoft.AzureIntegrationMigration.Tool.Mocks.Parse.csproj
@@ -2,6 +2,8 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
+    <CodeAnalysisTreatWarningsAsErrors>true</CodeAnalysisTreatWarningsAsErrors>
+    <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
 

--- a/tests/Microsoft.AzureIntegrationMigration.Tool.Mocks.Report/Microsoft.AzureIntegrationMigration.Tool.Mocks.Report.csproj
+++ b/tests/Microsoft.AzureIntegrationMigration.Tool.Mocks.Report/Microsoft.AzureIntegrationMigration.Tool.Mocks.Report.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <CodeAnalysisTreatWarningsAsErrors>true</CodeAnalysisTreatWarningsAsErrors>
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>

--- a/tests/Microsoft.AzureIntegrationMigration.Tool.Mocks.Report/Microsoft.AzureIntegrationMigration.Tool.Mocks.Report.csproj
+++ b/tests/Microsoft.AzureIntegrationMigration.Tool.Mocks.Report/Microsoft.AzureIntegrationMigration.Tool.Mocks.Report.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AzureIntegrationMigration.Runner" Version="0.5.1" />
+    <PackageReference Include="Microsoft.AzureIntegrationMigration.Runner" Version="0.5.2-beta.2021042827726" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="3.1.8" />
   </ItemGroup>
 

--- a/tests/Microsoft.AzureIntegrationMigration.Tool.Mocks.Report/Microsoft.AzureIntegrationMigration.Tool.Mocks.Report.csproj
+++ b/tests/Microsoft.AzureIntegrationMigration.Tool.Mocks.Report/Microsoft.AzureIntegrationMigration.Tool.Mocks.Report.csproj
@@ -2,6 +2,8 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
+    <CodeAnalysisTreatWarningsAsErrors>true</CodeAnalysisTreatWarningsAsErrors>
+    <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
 

--- a/tests/Microsoft.AzureIntegrationMigration.Tool.Mocks.Verify/Microsoft.AzureIntegrationMigration.Tool.Mocks.Verify.csproj
+++ b/tests/Microsoft.AzureIntegrationMigration.Tool.Mocks.Verify/Microsoft.AzureIntegrationMigration.Tool.Mocks.Verify.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <CodeAnalysisTreatWarningsAsErrors>true</CodeAnalysisTreatWarningsAsErrors>
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>

--- a/tests/Microsoft.AzureIntegrationMigration.Tool.Mocks.Verify/Microsoft.AzureIntegrationMigration.Tool.Mocks.Verify.csproj
+++ b/tests/Microsoft.AzureIntegrationMigration.Tool.Mocks.Verify/Microsoft.AzureIntegrationMigration.Tool.Mocks.Verify.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AzureIntegrationMigration.Runner" Version="0.5.1" />
+    <PackageReference Include="Microsoft.AzureIntegrationMigration.Runner" Version="0.5.2-beta.2021042827726" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="3.1.8" />
   </ItemGroup>
 

--- a/tests/Microsoft.AzureIntegrationMigration.Tool.Mocks.Verify/Microsoft.AzureIntegrationMigration.Tool.Mocks.Verify.csproj
+++ b/tests/Microsoft.AzureIntegrationMigration.Tool.Mocks.Verify/Microsoft.AzureIntegrationMigration.Tool.Mocks.Verify.csproj
@@ -2,6 +2,8 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
+    <CodeAnalysisTreatWarningsAsErrors>true</CodeAnalysisTreatWarningsAsErrors>
+    <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
 


### PR DESCRIPTION
## Description
Removed the beta versions of the code analyzers and upgraded to .net 5 to use the Analyzers provided by the SDK.
Updated the reference to the runner library to the latest beta version

## Checklist
- [ ] Only increment the version number following a GitHub Release.  Check this only if this PR is a version bump.